### PR TITLE
Fix render from within a partial

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ provided, we will watch all the input folders.
 Todo
 --------------------------------------------------
 
+- [ ] Consider adding `input_root` which will prefix all others
 - [ ] YAML loader (data_folder?)
 - [ ] CSV Loader (data_folder?)
 - [ ] Maybe: Render from/to Markdown

--- a/lib/bobkit/scope.rb
+++ b/lib/bobkit/scope.rb
@@ -2,8 +2,8 @@ module Bobkit
   class Scope
     include SlimBridge
 
-    def initialize(scope)
-      @scope = scope
+    def initialize(scope=nil)
+      @scope = scope || {}
     end
 
     def method_missing(method_name, *arguments, &block)

--- a/lib/bobkit/slim_bridge.rb
+++ b/lib/bobkit/slim_bridge.rb
@@ -3,6 +3,7 @@ module Bobkit
     include FileHelpers
     include SlimOptions
     include LocationOptions
+    include ScopeOptions
 
     def render(options={}, extra_options={})
       options = { partial: options }.merge(extra_options) if options.is_a? String
@@ -11,7 +12,9 @@ module Bobkit
       output  = options.delete :output
       
       context = options.empty? ? scope : options
-      context = Scope.new context if context.is_a? Hash
+      if context.is_a? Hash or !context
+        context = Scope.new context 
+      end
 
       content = Slim::Template.new("#{templates_folder}/#{partial}.slim", slim_options).render(context)
       content = Slim::Template.new("#{layouts_folder}/#{layout}.slim", slim_options).render(context) { content } if layout

--- a/spec/bobkit/slim_spec.rb
+++ b/spec/bobkit/slim_spec.rb
@@ -15,6 +15,11 @@ describe SlimBridge do
     expect(result).to match /is a simple partial/
   end
 
+  it "renders a simple partial from another partial" do
+    result = render 'simple_render'
+    expect(result).to match /is a simple partial/
+  end
+
   it "renders a partial with a hash scope" do
     result = render 'movie_partial', movie: 'Ace Ventura', actor: 'Jim Carrey'
     expect(result).to match /Movie: Ace Ventura/
@@ -44,4 +49,5 @@ describe SlimBridge do
     expect(File.exist?(outfile)).to be true
     expect(File.read(outfile)).to match /is a simple partial/
   end
+
 end

--- a/spec/fixtures/templates/simple_render.slim
+++ b/spec/fixtures/templates/simple_render.slim
@@ -1,0 +1,2 @@
+h3 testing render without parameters
+= render 'simple_partial'


### PR DESCRIPTION
Render was broken when calling `render 'some file'` from within a `slim` template, without providing scope.
