### PR TITLE
Fix partial with arguments in slim

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--format documentation

--- a/lib/bobkit/scope.rb
+++ b/lib/bobkit/scope.rb
@@ -10,7 +10,7 @@ module Bobkit
       if @scope.respond_to?(:key?) and @scope.key?(method_name)
         @scope[method_name]
       elsif @scope.respond_to? method_name
-        @scope.send method_name
+        @scope.send method_name, *arguments
       else
         super
       end

--- a/spec/bobkit/slim_spec.rb
+++ b/spec/bobkit/slim_spec.rb
@@ -20,19 +20,6 @@ describe SlimBridge do
     expect(result).to match /is a simple partial/
   end
 
-  it "renders a partial with a hash scope" do
-    result = render 'movie_partial', movie: 'Ace Ventura', actor: 'Jim Carrey'
-    expect(result).to match /Movie: Ace Ventura/
-    expect(result).to match /Actor: Jim Carrey/
-  end
-
-  it "renders a partial with an object scope" do
-    scope SpecUser.new
-    result = render 'user_partial'
-    expect(result).to match /Name: James Brown/
-    expect(result).to match /Email: james.brown@still-alive/
-  end
-
   it "renders a partial that calls another partial" do
     result = render 'babushka', name: 'Big Babushka'
     expect(result).to match /<h1>.*Big Babushka/m
@@ -49,5 +36,31 @@ describe SlimBridge do
     expect(File.exist?(outfile)).to be true
     expect(File.read(outfile)).to match /is a simple partial/
   end
+
+  context "with hash scope" do
+    it "renders a partial" do
+      result = render 'movie_partial', movie: 'Ace Ventura', actor: 'Jim Carrey'
+      expect(result).to match /Movie: Ace Ventura/
+      expect(result).to match /Actor: Jim Carrey/
+    end
+  end
+
+  context "with object scope" do
+    it "renders a partial" do
+      scope SpecUser.new
+      result = render 'user_partial'
+      expect(result).to match /Name: James Brown/
+      expect(result).to match /Email: james.brown@still-alive/
+    end
+
+    it "can access scope methods" do
+      scope SpecYoutube.new
+      result = render 'youtube_partial'
+      expect(result).to match /Cat vs Printer/
+      expect(result).to match /<video>large/
+      expect(result).to match /YouTube footer/
+    end
+  end
+
 
 end

--- a/spec/fixtures/templates/youtube_footer.slim
+++ b/spec/fixtures/templates/youtube_footer.slim
@@ -1,0 +1,1 @@
+footer YouTube footer reporting for duty

--- a/spec/fixtures/templates/youtube_partial.slim
+++ b/spec/fixtures/templates/youtube_partial.slim
@@ -1,0 +1,8 @@
+h2  Variable from scope:
+= video_name
+
+h2 Method from scope:
+= video_tag 'large'
+
+h2 Can still access 'render':
+= render 'youtube_footer'

--- a/spec/support.rb
+++ b/spec/support.rb
@@ -8,4 +8,14 @@ module TestSupport
       'james.brown@still-alive.com'
     end
   end
+
+  class SpecYoutube
+    def video_name
+      'Cat vs Printer'
+    end
+
+    def video_tag(size)
+      "<video>#{size}</video>"
+    end
+  end
 end


### PR DESCRIPTION
`= scope_method :with, :arguments` did not work inside a Slim template. Fixed.
