### PR TITLE
Slim: Add support for direct object rendering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 
 rvm:
   - "2.0.0"
-  - "2.3.1"
+  - "2.4.1"
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ html = render 'cats'
 scope email: 'bob@kit.com', name: 'Bob'
 html = render 'user'
 
+# You can render an object that responds to 'to_partial'
+# This method should return a path to the partial file
+user = User.new
+html = render user
+
 # You can send a scope directly to `render`
 html = render 'user', email: 'bob@kit.com', name: 'Bob'
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ scope email: 'bob@kit.com', name: 'Bob'
 html = render 'user'
 
 # You can render an object that responds to 'to_partial'
-# This method should return a path to the partial file
+# This method should return the name of the partial file
 user = User.new
 html = render user
 

--- a/bobkit.gemspec
+++ b/bobkit.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'runfile', '~> 0.1'
   s.add_development_dependency 'runfile-tasks', '~> 0.4'
-  s.add_development_dependency 'byebug', '~> 9.1'
+  s.add_development_dependency 'byebug', '~> 9.0'
   s.add_development_dependency 'rspec', '~> 3.6'
   s.add_development_dependency 'simplecov', '~> 0.15'
 end

--- a/bobkit.gemspec
+++ b/bobkit.gemspec
@@ -17,17 +17,17 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.0.0"
 
   s.add_runtime_dependency 'slim', "~> 3.0"
-  s.add_runtime_dependency 'sass', "~> 3.4"
+  s.add_runtime_dependency 'sass', "~> 3.5"
   s.add_runtime_dependency 'sass-globbing', '~> 1.1'
   s.add_runtime_dependency 'coffee-script', '~> 2.4'
-  s.add_runtime_dependency 'i18n', '~> 0.7'
+  s.add_runtime_dependency 'i18n', '~> 0.8'
   s.add_runtime_dependency 'filewatcher', '~> 0.5'
   s.add_runtime_dependency 'therubyracer', '~> 0.12'
   s.add_runtime_dependency 'rdiscount', '~> 2.2'
 
-  s.add_development_dependency 'runfile', '~> 0.9'
+  s.add_development_dependency 'runfile', '~> 0.1'
   s.add_development_dependency 'runfile-tasks', '~> 0.4'
-  s.add_development_dependency 'byebug', '~> 9.0'
-  s.add_development_dependency 'rspec', '~> 3.4'
-  s.add_development_dependency 'simplecov', '~> 0.14'
+  s.add_development_dependency 'byebug', '~> 9.1'
+  s.add_development_dependency 'rspec', '~> 3.6'
+  s.add_development_dependency 'simplecov', '~> 0.15'
 end

--- a/lib/bobkit/slim_bridge.rb
+++ b/lib/bobkit/slim_bridge.rb
@@ -13,7 +13,13 @@ module Bobkit
       include I18nBridge
 
       def render(options={}, extra_options={})
-        options = { partial: options }.merge(extra_options) if options.is_a? String
+        if options.is_a? String
+          options = { partial: options }.merge(extra_options) 
+        elsif options.respond_to? :to_partial
+          scope options
+          options = { partial: options.to_partial }.merge(extra_options) 
+        end
+
         partial = options.delete :partial
         layout  = options.delete :layout
         output  = options.delete :output

--- a/lib/bobkit/version.rb
+++ b/lib/bobkit/version.rb
@@ -1,3 +1,3 @@
 module Bobkit
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end

--- a/spec/bobkit/slim_bridge_spec.rb
+++ b/spec/bobkit/slim_bridge_spec.rb
@@ -44,6 +44,13 @@ describe SlimBridge do
     expect(File.read(outfile)).to match /is a simple partial/
   end
 
+  it "renders an object", :focus do
+    user = SpecUser.new
+    result = render user
+    expect(result).to match /Name: James Brown/
+    expect(result).to match /Email: james.brown@still-alive/
+  end
+
   context "with localization" do
     it "renders a localized string" do
       locale :fr

--- a/spec/support.rb
+++ b/spec/support.rb
@@ -7,6 +7,10 @@ module TestSupport
     def email
       'james.brown@still-alive.com'
     end
+
+    def to_partial
+      'user_partial'
+    end
   end
 
   class SpecYoutube


### PR DESCRIPTION
This PR adds support for rendering an object with this syntax:

```ruby
user = User.new
render user
```

The only requirement is that the rendered class (`User`) should have a `#to_partial` method that returns the name of its partial.

This is equivalent to:

```
scope User.new
render 'user'
```