### PR TITLE
Add bob class for non-dsl use

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,25 @@ compile_css 'main', output: 'style'
 See more examples in the [Examples folder][1]
 
 
+### DSL or Instance
+
+Bobkit was primarily designed as a DSL, but if you wish to use a more scoped
+approach, you can use an instance of the `Bob` class.
+
+```ruby
+require 'bobkit'
+
+# Option 1: DSL
+include Bobkit::Tasks
+render ...
+compile_css ...
+
+# Option 2: Bob class
+bob = Bob.new
+bob.render ...
+bob.compile_css
+```
+
 Reference
 --------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,25 @@ compile_css 'main', output: 'style'
 See more examples in the [Examples folder][1]
 
 
+### DSL or Instance
+
+Bobkit was primarily designed as a DSL, but if you wish to use a more scoped
+approach, you can use an instance of the `Bob` class.
+
+```ruby
+require 'bobkit'
+
+# Option 1: DSL
+include Bobkit::Tasks
+render ...
+compile_css ...
+
+# Option 2: Bob class
+bob = Bob.new
+bob.render ...
+bob.compile_css ...
+```
+
 Reference
 --------------------------------------------------
 

--- a/lib/bobkit.rb
+++ b/lib/bobkit.rb
@@ -24,3 +24,4 @@ require 'bobkit/watcher'
 
 require 'bobkit/scope'
 require 'bobkit/tasks'
+require 'bobkit/bob'

--- a/lib/bobkit/bob.rb
+++ b/lib/bobkit/bob.rb
@@ -1,0 +1,5 @@
+module Bobkit
+  class Bob
+    include Tasks
+  end
+end

--- a/spec/bobkit/bob_spec.rb
+++ b/spec/bobkit/bob_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe Bob do
+  subject { described_class.new }
+
+  it "has all methods from Tasks" do
+    expect(subject).to respond_to :render
+    expect(subject).to respond_to :copy_asset
+  end
+end


### PR DESCRIPTION
This PR adds a class that allows use of Bobkit's tasks, without including the DSL.

```ruby
bob = Bob.new
bob.render ...
bob.compile_css ...
```