### PR TITLE
Switch from therubyracer to mini_racer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ language: ruby
 cache: bundler
 
 rvm:
-  - "2.3.0"
-  - "2.5.3"
-  - "2.6.3"
+  - "2.3"
+  - "2.4"
+  - "2.5"
+  - "2.6"
 
 before_install:
 - gem install bundler

--- a/bobkit.gemspec
+++ b/bobkit.gemspec
@@ -17,11 +17,11 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.0.0"
 
   s.add_runtime_dependency 'slim', "~> 4.0"
-  s.add_runtime_dependency 'sass', "~> 3.5"
+  s.add_runtime_dependency 'sass', "~> 3.7"
   s.add_runtime_dependency 'sass-globbing', '~> 1.1'
   s.add_runtime_dependency 'coffee-script', '~> 2.4'
-  s.add_runtime_dependency 'i18n', '~> 1.0'
-  s.add_runtime_dependency 'filewatcher', '~> 1.0'
-  s.add_runtime_dependency 'therubyracer', '~> 0.12'
+  s.add_runtime_dependency 'i18n', '~> 1.7'
+  s.add_runtime_dependency 'filewatcher', '~> 1.1'
+  s.add_runtime_dependency 'mini_racer', '~> 0.2'
   s.add_runtime_dependency 'rdiscount', '~> 2.2'
 end


### PR DESCRIPTION
Due to the fact that therubyracer uses an older libv8 and seems to fall out of maintenance